### PR TITLE
Change set_build_target() to build.set_target()

### DIFF
--- a/plugins/build/init.lua
+++ b/plugins/build/init.lua
@@ -283,7 +283,7 @@ core.status_view:add_item({
         local has = false
         for i,v in ipairs(build.targets) do
           if text == v.name then
-            set_build_target(i)
+            build.set_target(i)
             has = true
           end
         end


### PR DESCRIPTION
Currently, changing the build target results in an error:
init.lua:286: cannot get undefined variable: set_build_target.
This commit fixes it